### PR TITLE
weird boxes and frame count

### DIFF
--- a/book-mode.el
+++ b/book-mode.el
@@ -79,6 +79,10 @@
   :type 'boolean
   :group 'book-mode)
 
+(defcustom book-mode-display-frame-index nil
+  "Whether to display frame index"
+  :type 'boolean
+  :group 'book-mode)
 
 (defun book-mode--log (format-string &rest args)
   "Log a message into the *Messages* buffer if message-log-max is
@@ -239,7 +243,7 @@ saves the message in a buffer local variable."
   "Prefix element displaying frame count and an icon."
   
   (concat
-   (book-mode-element-frame-count)
+   (if book-mode-display-frame-index (book-mode-element-frame-count) (book-mode-element-empty))
    "   "
    (cond (icon 
           (propertize (format "%s " icon) 'face 'nano-default))

--- a/book-mode.el
+++ b/book-mode.el
@@ -626,6 +626,10 @@ saves the message in a buffer local variable."
                            :background (face-background 'default))
   (face-remap-add-relative 'window-divider
                            :foreground (face-foreground 'default))
+
+  (face-remap-set-base 'mode-line nil)
+  (face-remap-set-base 'mode-line-inactive nil)
+
   (face-remap-add-relative 'mode-line
                            :foreground (face-foreground 'default)
                            :background (face-background 'default)


### PR DESCRIPTION
I raised issue [4](https://github.com/rougier/book-mode/issues/4) describing weird box at the bottom. This PR propose to reset mode-line faces set by nano-theme which incidentally  remove theses drawings. 
Also , in my config (void + i3wm ) i mainly use one and only one frame hence the frame count is unnecessary . I added a custom variable allowing one to mask the drawing of frame count. 